### PR TITLE
chore(renovate): preserve semver ranges in dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,3 +1,3 @@
 {
-  extends: ['github>fohte/renovate-config:base.json5'],
+  extends: ['github>fohte/renovate-config:base.json5', ':preserveSemverRanges'],
 }


### PR DESCRIPTION
## Why

- For Rust binary crates, maintaining SemVer ranges is the best practice
- Pinning like #8 is unnecessary

## What

- Add `:preserveSemverRanges` preset to Renovate configuration