### PR TITLE
ci: Add PR title validation

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,20 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          # Custom pattern to support breaking changes with exclamation mark
+          # Matches: type, type!, type(scope), type!(scope) only
+          headerPattern: '^(\w+)(!)?(?:\(([\w$.\-*/ ]*)\))?:\s*(.*)$'
+          headerPatternCorrespondence: type, _, scope, subject
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ feat!: change default behavior for trailing newlines
 
 1. **Merge PRs**: When PRs with conventional commit messages are merged to `master`, release-please tracks them
 2. **Release PR Creation**: release-please automatically creates/updates a Release PR that:
-   - Bumps version in `Cargo.toml` based on commit types
-   - Generates/updates `CHANGELOG.md`
-   - Creates a GitHub release draft
+    - Bumps version in `Cargo.toml` based on commit types
+    - Generates/updates `CHANGELOG.md`
+    - Creates a GitHub release draft
 3. **Publish**: When the Release PR is merged:
-   - A new GitHub release and git tag are created
-   - The package is automatically published to crates.io
+    - A new GitHub release and git tag are created
+    - The package is automatically published to crates.io
 
 **Version Bumping Rules:**
 - `feat:` commits → minor version bump (0.1.0 → 0.2.0)

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ feat!: change default behavior for trailing newlines
 
 #### How Releases Work
 
-1. **Merge PRs**: When PRs with conventional commit messages are merged to `master`, release-please tracks them
+1. **Merge PRs**: When PRs with conventional commit messages are merged to the default branch (`master`), release-please tracks them
 2. **Release PR Creation**: release-please automatically creates/updates a Release PR that:
     - Bumps version in `Cargo.toml` based on commit types
     - Generates/updates `CHANGELOG.md`
@@ -157,9 +157,15 @@ feat!: change default behavior for trailing newlines
     - The package is automatically published to crates.io
 
 **Version Bumping Rules:**
-- `feat:` commits → minor version bump (0.1.0 → 0.2.0)
+
+After 1.0.0:
+- `feat:` commits → minor version bump (1.0.0 → 1.1.0)
+- `fix:` commits → patch version bump (1.0.0 → 1.0.1)
+- Breaking changes (`!`) → major version bump (1.0.0 → 2.0.0)
+
+Before 1.0.0 (with `bump-minor-pre-major` and `bump-patch-for-minor-pre-major`):
+- `feat:` commits → patch version bump (0.1.0 → 0.1.1)
 - `fix:` commits → patch version bump (0.1.0 → 0.1.1)
-- Breaking changes (`!`) → major version bump (0.1.0 → 1.0.0)
-- Before 1.0.0: `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` are enabled
+- Breaking changes (`!`) → minor version bump (0.1.0 → 0.2.0)
 
 **Note:** This repository uses squash merge strategy, so the PR title becomes the commit message. Always ensure your PR title follows the Conventional Commits format.

--- a/README.md
+++ b/README.md
@@ -105,3 +105,61 @@ Common patterns:
 - `*.generated.*`: Exclude generated files
 
 If `.basefmt.toml` doesn't exist, basefmt will format all files except those in `.gitignore`.
+
+## Contributing
+
+### Release Process
+
+This project uses [release-please](https://github.com/googleapis/release-please) for automated releases based on [Conventional Commits](https://www.conventionalcommits.org/).
+
+#### Conventional Commit Format
+
+All PR titles must follow the Conventional Commits format (enforced by CI):
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Common types:**
+- `feat:` - New feature (triggers minor version bump)
+- `fix:` - Bug fix (triggers patch version bump)
+- `docs:` - Documentation changes
+- `chore:` - Maintenance tasks
+- `ci:` - CI/CD changes
+- `refactor:` - Code refactoring
+- `test:` - Test additions or changes
+
+**Breaking changes:**
+- Add `!` after the type to indicate breaking changes: `feat!:` or `fix!:`
+- Breaking changes trigger a major version bump
+
+**Examples:**
+```
+feat: add support for custom formatting rules
+fix: handle empty files correctly
+docs: update installation instructions
+feat!: change default behavior for trailing newlines
+```
+
+#### How Releases Work
+
+1. **Merge PRs**: When PRs with conventional commit messages are merged to `master`, release-please tracks them
+2. **Release PR Creation**: release-please automatically creates/updates a Release PR that:
+   - Bumps version in `Cargo.toml` based on commit types
+   - Generates/updates `CHANGELOG.md`
+   - Creates a GitHub release draft
+3. **Publish**: When the Release PR is merged:
+   - A new GitHub release and git tag are created
+   - The package is automatically published to crates.io
+
+**Version Bumping Rules:**
+- `feat:` commits → minor version bump (0.1.0 → 0.2.0)
+- `fix:` commits → patch version bump (0.1.0 → 0.1.1)
+- Breaking changes (`!`) → major version bump (0.1.0 → 1.0.0)
+- Before 1.0.0: `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` are enabled
+
+**Note:** This repository uses squash merge strategy, so the PR title becomes the commit message. Always ensure your PR title follows the Conventional Commits format.


### PR DESCRIPTION
## Why

- PR titles must follow Conventional Commits format for release-please to work correctly with squash merge strategy

## What

- Add GitHub Actions workflow to validate PR titles against Conventional Commits format when PRs are opened or edited
- Add release process documentation to README explaining Conventional Commits format, release-please workflow, and version bumping rules
