### PR TITLE
ci: manage Rust toolchain with rust-toolchain.toml instead of mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
 
       - uses: jdx/mise-action@v2
 
+      - run: rustup show
+
       - name: Run lefthook
         id: lefthook
         continue-on-error: true
@@ -71,6 +73,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: jdx/mise-action@v2
+
+      - run: rustup show
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,4 @@
 [tools]
-rust = { version = "1.92.0", profile = "default" }
 lefthook = "2.0.12"
 
 # lefthook hooks

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION

## Why

- Same as https://github.com/fohte/armyknife/pull/19
- `mise-action`'s cache only covers `~/.local/share/mise`, but Rust toolchain is installed to `~/.rustup` and `~/.cargo`
- This caused `clippy`/`rustfmt` to be missing after cache restore, failing CI

## What

- Stop managing Rust with `mise` and use `rust-toolchain.toml` instead

### Why stop using mise for Rust toolchain

- `mise-action`'s cache doesn't cover `~/.rustup` and `~/.cargo`, requiring custom cache configuration
- When using `cargo install`, both mise-installed and cargo-installed binaries end up in `~/.cargo`, making cache strategy difficult
  - For example, both `.mise.toml` and `Cargo.lock` hashes would need to be included in the cache key

### Why adopt `rust-toolchain.toml`

- `rustup` natively supports `rust-toolchain.toml`, automatically installing toolchain and components with just `rustup show`
- Same config file can be shared between local and CI, with no external action dependency
