### PR TITLE
ci: upload pre-built binaries to GitHub Releases on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,14 +3,22 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to upload assets to (e.g., v0.1.1)'
+        required: true
+        type: string
 
 name: release-please
 
 jobs:
   release-please:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -24,6 +32,77 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-merge release PR to enable automatic releases on every merge to master
+      - name: Auto-merge release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          # Try --auto first (enables auto-merge when CI is pending/required)
+          # If PR is already in clean status, --auto fails with 'Pull request is in clean status'
+          # In that case, fall back to direct merge
+          if OUTPUT=$(gh pr merge "$PR_NUMBER" --squash --auto -R "${{ github.repository }}" 2>&1); then
+            echo "$OUTPUT"
+            echo "Auto-merge enabled successfully"
+          elif echo "$OUTPUT" | grep -q "clean status"; then
+            echo "$OUTPUT"
+            echo "PR is in clean status, merging directly"
+            gh pr merge "$PR_NUMBER" --squash -R "${{ github.repository }}"
+          else
+            echo "$OUTPUT"
+            echo "Auto-merge failed with unexpected error"
+            exit 1
+          fi
+
+  build-release:
+    needs: release-please
+    # always() is required because release-please job is skipped on workflow_dispatch,
+    # and dependent jobs skip without evaluating their if condition by default.
+    if: always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      RUSTC_WRAPPER: 'sccache'
+      SCCACHE_LOG: 'debug'
+    steps:
+      - uses: actions/checkout@v6
+
+      - run: rustup show
+
+      - run: rustup target add ${{ matrix.target }}
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../basefmt-${{ matrix.target }}.tar.gz basefmt
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.tag_name || needs.release-please.outputs.tag_name }}
+        run: |
+          gh release upload "$TAG_NAME" \
+            basefmt-${{ matrix.target }}.tar.gz
 
   publish:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,6 +80,8 @@ jobs:
       SCCACHE_LOG: 'debug'
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
 
       - run: rustup show
 


### PR DESCRIPTION
## Why

- Pre-built binaries should be available for download from GitHub Releases
- Release-please PRs should be auto-merged to fully automate the release flow

## What

- Build for 3 targets (aarch64-apple-darwin, x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu) on release creation and upload `tar.gz` archives to the GitHub Release
- Support `workflow_dispatch` to manually upload assets to existing releases
- Auto-merge release-please PRs

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/basefmt/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
