### PR TITLE
ci: pin mise version to 2026.6.6

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -121,6 +121,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.6.6
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.6.6
 
       - run: rustup show
 


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/428
- Align the mise version across the org so every workflow uses the same toolchain
