### PR TITLE
chore: set repo_id in copier answers

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -10,7 +10,7 @@ is_public: true
 project_name: basefmt
 release_binary: true
 release_type: rust
-repo_id: ''
+repo_id: '1064924625'
 repo_language: en
 subpackages: []
 type: rust


### PR DESCRIPTION
## Purpose

- Template updates no longer reach this repository
    - The `boilerplate-update` workflow patches `repo_id` in `.copier-answers.yml` in place and never commits it
    - The `copier update` that runs next aborts with `Destination repository is dirty`

## Approach

- Write the real repository ID into `repo_id`, which leaves the patching step with nothing to do
    - The same ID is what the octo-sts trust policy templates interpolate into `subject_pattern`