### PR TITLE
chore: read octo-sts trust policies from this repository

### DIFF
--- a/.github/workflows/boilerplate-update.yml
+++ b/.github/workflows/boilerplate-update.yml
@@ -28,7 +28,7 @@ jobs:
         id: octo-sts
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-boilerplate-update
           domain: octo-sts.fohte.net
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}-release-please
           domain: octo-sts.fohte.net
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
-          scope: fohte
+          scope: ${{ github.repository }}
           identity: ${{ github.event.repository.name }}
           domain: octo-sts.fohte.net
 


### PR DESCRIPTION
## Purpose

- The workflows still federate against `fohte/.github`, so this repository's name and the identities it uses stay readable there
- Its own trust policies are already on the default branch, so nothing depends on the aggregate anymore

## Approach

- Point the octo-sts steps at `${{ github.repository }}`
    - Under a repo scope octo-sts reads `.github/chainguard/` from this repository and pins the token to it, so the `repositories:` key the aggregate carried is no longer needed
- Removing the entries from `fohte/.github` follows separately, once every repository has switched